### PR TITLE
s3regrid

### DIFF
--- a/GbcsKinds.f90
+++ b/GbcsKinds.f90
@@ -1,0 +1,89 @@
+!------------------------------------------------------------------------
+!
+!    Copyright 2021 Owen Embury, and Claire Bulgin
+!    Department of Meteorology, University of Reading, UK
+!
+!    This file is part of the GBCS software package.
+!
+!    The GBCS software package is free software: you can redistribute it
+!    and/or modify it under the terms of the GNU General Public License
+!    as published by the Free Software Foundation, either version 3 of
+!    the License, or (at your option) any later version.
+!
+!    The GBCS software package is distributed in the hope that it will be
+!    useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+!    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with the GBCS software package.
+!    If not, see <http://www.gnu.org/licenses/>.
+!
+!------------------------------------------------------------------------
+
+
+
+!+ This module contains the definition of GBCS real data kinds
+
+MODULE GbcsKinds
+
+!
+! Description:
+!
+!  Define byte size limits for generic kinds used in the GBCS code
+!
+! Method:
+!
+!  Use the FORTRAN SELECTED KIND functions to define the following kinds
+!
+!    1 byte integer
+!    2 byte integer
+!    4 byte integer
+!    8 byte integer
+!
+!    4 byte real
+!    8 byte real
+!
+!
+! Owner: Manager of TRICS Project
+!
+! History:
+! Version  Date       Comment
+! -------  ----       -------
+! 0.0   03/01/2005    Creation                                                   CPO
+!
+!
+! Code Description:
+!   Language:            Fortran 90
+!
+!
+! Institute of Atmospheric and Environmental Sciences
+! The University of Edinburgh, The Crew Building, The King's Buildings
+! West Mains Road, Edinburgh, UK  EH9 3JN
+!
+
+! Declarations:
+
+! Modules used:
+
+  IMPLICIT NONE
+
+  CHARACTER(LEN=50), PARAMETER, PRIVATE :: Module_Name = 'GbcsKinds.mod'
+
+! Global Declarations:
+
+  INTEGER, PARAMETER :: GbcsInt1 = SELECTED_INT_KIND( 2 )                     ! 1 byte integer
+  INTEGER, PARAMETER :: GbcsInt2 = SELECTED_INT_KIND( 4 )                     ! 2 byte integer
+  INTEGER, PARAMETER :: GbcsInt4 = SELECTED_INT_KIND( 9 )                     ! 4 byte integer
+  INTEGER, PARAMETER :: GbcsInt8 = SELECTED_INT_KIND( 18 )                    ! 8 byte integer
+
+  INTEGER, PARAMETER :: GbcsReal = SELECTED_REAL_KIND( P =  6 , R =  37 )     ! 4 byte real
+  INTEGER, PARAMETER :: GbcsDble = SELECTED_REAL_KIND( P = 13 , R = 300 )     ! 8 byte real
+
+! Global named constants:
+
+! Global Type Definitions:
+
+! Various lengths and limits
+
+END MODULE GbcsKinds

--- a/GbcsNetCDF.f90
+++ b/GbcsNetCDF.f90
@@ -1,0 +1,1418 @@
+!------------------------------------------------------------------------------
+!M+
+! NAME:
+!       GbcsNetCDF
+!
+! PURPOSE:
+!>      Routines for interfacing with the NetCDF library and applying
+!>      automatic scaling where appropriate
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-2003
+!
+! CALLING SEQUENCE:
+!       USE GbcsNetCDF
+!
+! PUBLIC DATA:
+!       None
+!
+! MODULES:
+!       GbcsKinds
+!       netcdf
+!
+! CONTAINS:
+!       Get_DimID
+!       Dim_Length
+!       Get_VarID
+!       Get_VarInfo
+!       Get_Var_Dimensions
+!       Write_Var
+!       Quantize
+!
+! DERIVED TYPES:
+!       VarInfo (private)
+!
+! NOTES:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 08/03/2011
+!                     IAES, University of Edinburgh
+!
+!    Copyright 2021 Owen Embury, and Claire Bulgin
+!    Department of Meteorology, University of Reading, UK
+!
+!    This file is part of the GBCS software package.
+!
+!    The GBCS software package is free software: you can redistribute it
+!    and/or modify it under the terms of the GNU General Public License
+!    as published by the Free Software Foundation, either version 3 of
+!    the License, or (at your option) any later version.
+!
+!    The GBCS software package is distributed in the hope that it will be
+!    useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+!    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with the GBCS software package.
+!    If not, see <http://www.gnu.org/licenses/>.
+!M-
+!------------------------------------------------------------------------------
+MODULE GbcsNetCDF
+  ! ------------
+  ! Modules used
+  ! ------------
+  USE GbcsKinds
+  USE netcdf
+  USE iso_c_binding
+
+  ! ---------------------------
+  ! Disable all implicit typing
+  ! ---------------------------
+  IMPLICIT NONE
+  PRIVATE
+
+  PUBLIC :: Get_DimID, Dim_Length
+  PUBLIC :: Find_VarID, Get_VarID, Get_VarInfo, Get_Var_Dimensions
+  PUBLIC :: Write_Var
+  PUBLIC :: Quantize
+  PUBLIC :: nf90_strerror
+
+  ! --------------------
+  ! Function overloading
+  ! --------------------
+  INTERFACE Write_Var
+    MODULE PROCEDURE Write_Var1F, Write_Var1I, &
+                     Write_Var2D, Write_Var2F, &
+                     Write_Var2I, Write_Var2S, Write_Var2B
+  END INTERFACE Write_Var
+
+  INTERFACE Pack_Data
+    MODULE PROCEDURE Pack_Data_Single, Pack_Data_Double
+  END INTERFACE Pack_Data
+
+  INTERFACE Unpack_Data
+    MODULE PROCEDURE Unpack_Data_Single, Unpack_Data_Double
+  END INTERFACE Unpack_Data
+
+  INTERFACE Quantize
+    MODULE PROCEDURE Quantize_Scalar, Quantize_1F, Quantize_2F, &
+                     Quantize_2D
+  END INTERFACE Quantize
+
+
+  ! -------------
+  ! Derived Types
+  ! -------------
+  TYPE VarInfo
+    LOGICAL :: Is_Packed = .FALSE.
+    LOGICAL :: Has_Range = .FALSE.
+    LOGICAL :: Has_Fill  = .FALSE.
+    LOGICAL :: Use_lsd   = .FALSE.
+    REAL    :: offset    = 0.0
+    REAL    :: scale     = 1.0
+    REAL    :: precision = -1.0
+    REAL    :: valid_min =-HUGE(0.0)
+    REAL    :: valid_max = HUGE(0.0)
+    REAL    :: value_min =-HUGE(0.0)
+    REAL    :: value_max = HUGE(0.0)
+    REAL    :: fillvalue
+  END TYPE VarInfo
+
+  ! -----------------
+  ! Module parameters
+  ! -----------------
+  INTEGER, PRIVATE, PARAMETER :: max_nc_dims = 8
+
+  ! -- Module name for error messages
+  CHARACTER( * ), PRIVATE, PARAMETER :: MODULE_NAME = &
+    'GbcsMod_DataReaders/GbcsNetCDF.f90'
+
+CONTAINS
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Get_DimID
+!
+! PURPOSE:
+!>      Find the NetCDF dimid for the given dimension name
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       dimid = Get_DimID(ncid, name)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{name, in, CHARACTER(*)} dimension name
+!
+! FUNCTION RESULT:
+!>@RES{dimid, INTEGER} netCDF dimension ID or -1 on error
+!
+! CALLS:
+!       nf90_inq_dimid
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!>@PRO  This is just a wrapper around nf90_inq_dimid which sets the returned
+!>      dimid to -1 on error.
+!
+! CREATION HISTORY:
+!       11/03/11  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Get_DimID(ncid, name)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,          INTENT(IN) :: ncid
+    CHARACTER(LEN=*), INTENT(IN) :: name
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER                      :: Get_DimID
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Get_DimID'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status
+
+    status = nf90_inq_dimid(ncid, name, Get_DimID)
+    IF (status /= nf90_noerr) Get_DimID = -1
+
+  END FUNCTION Get_DimID
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Dim_Length
+!
+! PURPOSE:
+!>      Get the length of the specified dimension
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       len = Dim_Length(ncid, name)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{name, in, CHARACTER(*)} dimension name
+!
+! FUNCTION RESULT:
+!>@RES{length, INTEGER} Length of dimension or -1 on error
+!
+! CALLS:
+!       nf90_inq_dimid
+!       nf90_inquire_dimension
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!>@PRO  This is just a wrapper around nf90_inq_dimid / nf90_inquire_dimension
+!>      which sets the returned length to -1 on error
+!
+! CREATION HISTORY:
+!       10/03/11  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Dim_Length(ncid, name)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,          INTENT(IN) :: ncid
+    CHARACTER(LEN=*), INTENT(IN) :: name
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER                      :: Dim_Length
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Dim_Length'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status, dimid
+
+    Dim_Length = -1
+
+    status = nf90_inq_dimid(ncid, name, dimid)
+    IF (status /= nf90_noerr) RETURN
+
+    status = nf90_inquire_dimension(ncid, dimid, LEN=Dim_Length)
+
+  END FUNCTION Dim_Length
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Get_VarID
+!
+! PURPOSE:
+!>      Find the NetCDF varid for the given variable name
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       varid = Get_VarID(ncid, name)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{name, in, CHARACTER(*)} dimension name
+!>@ARG{errmsg, in, CHARACTER(*)\, OPTIONAL} Display this message on error
+!
+! FUNCTION RESULT:
+!>@RES{varid, INTEGER} netCDF variable ID or -1 on error
+!
+! CALLS:
+!       nf90_inq_varid
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!>@PRO  This is just a wrapper around nf90_inq_varid which sets the returned
+!>      varid to -1 on error.
+!
+! CREATION HISTORY:
+!       11/03/11  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Get_VarID(ncid, name, errmsg)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                    INTENT(IN) :: ncid
+    CHARACTER(LEN=*),           INTENT(IN) :: name
+    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: errmsg
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER                      :: Get_VarID
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Get_VarID'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status
+
+    IF (name == '') THEN
+      Get_VarID = -1
+      RETURN
+    END IF
+    status = nf90_inq_varid(ncid, name, Get_VarID)
+    IF (status /= nf90_noerr) Get_VarID = -1
+    IF (PRESENT(errmsg) .AND. status /= nf90_noerr) THEN
+      WRITE(*,*) errmsg//" Unable to read: "//name
+    END IF
+
+  END FUNCTION Get_VarID
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Find_VarID
+!
+! PURPOSE:
+!>      Search for a netCDF variable with the specified metadata
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       varid = Find_VarID(ncid, standard_name, axis)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{standard_name, in, CHARACTER(*)\, OPTIONAL} standard_name to match
+!>@ARG{standard_name, in, CHARACTER(*)\, OPTIONAL} axis to match
+!
+! FUNCTION RESULT:
+!>@RES{varid, INTEGER} netCDF variable ID or -1 on error
+!
+! CALLS:
+!       nf90_inq_varid
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       26/10/2018  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Find_VarID(ncid, standard_name, axis)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                    INTENT(IN) :: ncid
+    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: standard_name
+    CHARACTER(LEN=*), OPTIONAL, INTENT(IN) :: axis
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER                      :: Find_VarID
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Find_VarID'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status, nvar, varid
+    CHARACTER(LEN=60) :: name
+
+    Find_VarID = -1
+
+    status = nf90_inquire(ncid, nVariables=nvar)
+    IF (status /= nf90_noerr) RETURN
+
+    DO varid=1, nvar
+      IF (PRESENT(standard_name)) THEN
+        status = nf90_get_att(ncid, varid, "standard_name", name)
+        IF (status /= 0) CYCLE
+        IF (TRIM(name) /= standard_name) CYCLE
+      END IF
+      IF (PRESENT(axis)) THEN
+        status = nf90_get_att(ncid, varid, "axis", name)
+        IF (status /= 0) CYCLE
+        IF (TRIM(name) /= axis) CYCLE
+      END IF
+
+      Find_VarID = varid
+    END DO
+
+  END FUNCTION Find_VarID
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Get_VarInfo
+!
+! PURPOSE:
+!>      Get special CF attributes for variable packing, range etc.
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       inf = Get_VarInfo(ncid, varid)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{varid, in, INTEGER} netCDF variable id
+!
+! FUNCTION RESULT:
+!>@RES{varinfo, gbcsnetcdf::varinfo} VarInfo structure
+!
+! CALLS:
+!       nf90_get_att
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+!
+! CREATION HISTORY:
+!       17/05/12  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Get_VarInfo(ncid, varid) RESULT(inf)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,          INTENT(IN) :: ncid
+    INTEGER,          INTENT(IN) :: varid
+
+    ! ---------
+    ! Function result
+    ! ---------
+    TYPE(VarInfo)                :: inf
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Get_VarInfo'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status
+    REAL               :: rvalue
+    REAL, DIMENSION(2) :: range
+
+    status = nf90_get_att(ncid, varid, "add_offset", rvalue)
+    IF (status == nf90_noerr) THEN
+      inf%Is_Packed = .TRUE.
+      inf%offset = rvalue
+    END IF
+    status = nf90_get_att(ncid, varid, "scale_factor", rvalue)
+    IF (status == nf90_noerr) THEN
+      inf%Is_Packed = .TRUE.
+      inf%scale = rvalue
+    END IF
+    status = nf90_get_att(ncid, varid, "least_significant_digit", rvalue)
+    IF (status == nf90_noerr) THEN
+      inf%Use_lsd = .TRUE.
+      inf%precision = rvalue
+    END IF
+
+    status = nf90_get_att(ncid, varid, "valid_range", range)
+    IF (status == nf90_noerr) THEN
+      inf%Has_Range = .TRUE.
+      inf%valid_min = range(1)
+      inf%valid_max = range(2)
+      inf%value_min = inf%offset + inf%scale*inf%valid_min
+      inf%value_max = inf%offset + inf%scale*inf%valid_max
+    ELSE
+      ! Try checking valid_min / valid_max attributes
+      status = nf90_get_att(ncid, varid, "valid_min", rvalue)
+      IF (status == nf90_noerr) THEN
+        inf%Has_Range = .TRUE.
+        inf%valid_min = rvalue
+        inf%value_min = inf%offset + inf%scale*inf%valid_min
+      END IF
+      status = nf90_get_att(ncid, varid, "valid_max", rvalue)
+      IF (status == nf90_noerr) THEN
+        inf%Has_Range = .TRUE.
+        inf%valid_max = rvalue
+        inf%value_max = inf%offset + inf%scale*inf%valid_max
+      END IF
+    END IF
+
+    status = nf90_get_att(ncid, varid, "_FillValue", inf%fillvalue)
+    inf%Has_Fill = status == nf90_noerr
+
+  END FUNCTION Get_VarInfo
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Get_Var_Dimensions
+!
+! PURPOSE:
+!>      Get the variable dimensions
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       ndims = Get_Var_Dimensions(ncid, varid, dimids)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} netCDF file id
+!>@ARG{varid, in, INTEGER} netCDF variable id
+!>@ARG{dimids, out, INTEGER(:)} dimension ids
+!
+! FUNCTION RESULT:
+!>@RES{ndims, INTEGER} If positive: Number of dimensions; otherwise NetCDF error status
+!
+! CALLS:
+!       nf90_inquire_dimension
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+!
+! CREATION HISTORY:
+!       11/03/11  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  FUNCTION Get_Var_Dimensions(ncid, varid, dimids)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                         INTENT(IN)  :: ncid
+    INTEGER,                         INTENT(IN)  :: varid
+    INTEGER, DIMENSION(max_nc_dims), INTENT(OUT) :: dimids
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER                             :: Get_Var_Dimensions
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),  PARAMETER :: ROUTINE_NAME = 'Get_Var_Dimensions'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: ndims
+
+    Get_Var_Dimensions = nf90_inquire_variable(ncid, varid, ndims=ndims, dimids=dimids)
+    IF (Get_Var_Dimensions == nf90_noerr) Get_Var_Dimensions = ndims
+
+  END FUNCTION Get_Var_Dimensions
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Pack_Data
+!
+! PURPOSE:
+!>      Applys scale/offset transformation for packing data into short or byte
+!>      integers. The function rounds to the nearest whole number but does not
+!>      convert the type to integer. That should be done by the NetCDF library
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       CALL Pack_Data(value, inf)
+!
+! ARGUMENTS:
+!>@ARG{value, inout, REAL} value to pack
+!>@ARG{inf, in, gbcsnetcdf::varinfo} VarInfo structure
+!
+! CALLS:
+!       None
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 09/03/2011
+!                     IAES, University of Edinburgh
+!F-
+!------------------------------------------------------------------------------
+  ELEMENTAL SUBROUTINE Pack_Data_Single(value, inf)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL,          INTENT(INOUT) :: value
+    TYPE(VarInfo), INTENT(IN)    :: inf
+
+    IF (inf%Has_Range .AND. inf%Has_Fill) THEN
+      IF ((value < inf%value_min) .OR. (value > inf%value_max)) THEN
+        value = inf%fillvalue
+        RETURN
+      END IF
+    END IF
+
+    value = ANINT((value - inf%offset) / inf%scale)
+
+  END SUBROUTINE Pack_Data_Single
+
+  ELEMENTAL SUBROUTINE Pack_Data_Double(value, inf)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL(KIND=GbcsDble), INTENT(INOUT) :: value
+    TYPE(VarInfo),       INTENT(IN)    :: inf
+
+    IF (inf%Has_Range .AND. inf%Has_Fill) THEN
+      IF ((value < inf%value_min) .OR. (value > inf%value_max)) THEN
+        value = inf%fillvalue
+        RETURN
+      END IF
+    END IF
+
+    value = ANINT((value - inf%offset) / inf%scale)
+
+  END SUBROUTINE Pack_Data_Double
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Unpack_Data
+!
+! PURPOSE:
+!>      Applys scale/offset transformation for unpacking data from short or
+!>      byte integers.
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       CALL = Unpack_Data(value, inf)
+!
+! ARGUMENTS:
+!>@ARG{value, inout, REAL} packed data
+!>@ARG{inf, in, gbcsnetcdf::varinfo} VarInfo structure
+!
+! CALLS:
+!       None
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 09/03/2011
+!                     IAES, University of Edinburgh
+!F-
+!------------------------------------------------------------------------------
+  ELEMENTAL SUBROUTINE Unpack_Data_Single(value, inf)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL,          INTENT(INOUT) :: value
+    TYPE(VarInfo), INTENT(IN)    :: inf
+
+    IF (inf%Has_Range .AND. &
+        ((value < inf%valid_min) .OR. (value > inf%valid_max))) THEN
+      RETURN
+    ELSE
+      value = inf%offset + (value * inf%scale)
+    END IF
+
+  END SUBROUTINE Unpack_Data_Single
+
+  ELEMENTAL SUBROUTINE Unpack_Data_Double(value, inf)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL(KIND=GbcsDble), INTENT(INOUT) :: value
+    TYPE(VarInfo),       INTENT(IN)    :: inf
+
+    IF (inf%Has_Range .AND. &
+        ((value < inf%valid_min) .OR. (value > inf%valid_max))) THEN
+      RETURN
+    ELSE
+      value = inf%offset + (value * inf%scale)
+    END IF
+
+  END SUBROUTINE Unpack_Data_Double
+
+
+!------------------------------------------------------------------------------
+!S+
+! NAME:
+!       Get_Var_Ranges
+!
+! PURPOSE:
+!>      Internal subroutine for calculating the nc_start, nc_count arguments
+!>      when for read/writting a subset of a netCDF variable to an array which
+!>      may have fewer dimensions.
+!>
+!>      start and count refer to the in memory array which may have fewer
+!>      dimensions than the netCDF variable.
+!>      start is assumed to correspond to the slowest varying dimensions
+!>      count is assumed to correspond to the fastest varying dimensions
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       CALL Get_Var_Ranges(start, count, nc_ndims, nc_start, nc_count, nc_map, remap)
+!
+! ARGUMENTS:
+!>@ARG{start, in, INTEGER(:)}
+!>@ARG{count, in, INTEGER(:)}
+!>@ARG{nc_ndims, in, INTEGER}
+!>@ARG{nc_start, out, INTEGER(max_nc_dims)}
+!>@ARG{nc_count, out, INTEGER(max_nc_dims)}
+!>@ARG{nc_map, out, INTEGER(max_nc_dims)}
+!>@ARG{remap, in, INTEGER(:)}
+!
+! CALLS:
+!       None
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 14/01/2013
+!                     IAES, University of Edinburgh
+!S-
+!------------------------------------------------------------------------------
+  PURE SUBROUTINE Get_Var_Ranges(start, count, nc_ndims, nc_start, nc_count, nc_map, remap)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER, DIMENSION(:),           INTENT(IN)  :: start
+    INTEGER, DIMENSION(:),           INTENT(IN)  :: count
+    INTEGER,                         INTENT(IN)  :: nc_ndims
+    INTEGER, DIMENSION(max_nc_dims), INTENT(OUT) :: nc_start
+    INTEGER, DIMENSION(max_nc_dims), INTENT(OUT) :: nc_count
+    INTEGER, DIMENSION(max_nc_dims), INTENT(OUT) :: nc_map
+    INTEGER, DIMENSION(:), OPTIONAL, INTENT(IN)  :: remap
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: i, ndims
+
+    nc_start        = 1
+    IF (SIZE(start) > nc_ndims) THEN
+      ! Number of dimensions of memory array exceeds that of netCDF variable
+      nc_start(1:nc_ndims) = start(1:nc_ndims)
+    ELSE
+      nc_start(nc_ndims+1-SIZE(start):nc_ndims) = start
+    END IF
+
+    ndims = SIZE(count)
+    nc_count        = 1
+    nc_count(1:ndims)   = count
+
+    nc_map          = 1
+    nc_map(1:ndims) = (/1, (PRODUCT(count(:i)), i=1, ndims-1) /)
+
+    IF (PRESENT(remap)) THEN
+      ndims = SIZE(remap)
+      nc_start(1:ndims) = nc_start(remap)
+      nc_count(1:ndims) = nc_count(remap)
+      nc_map(1:ndims)   = nc_map(remap)
+    END IF
+
+  END SUBROUTINE Get_Var_Ranges
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var
+!
+! PURPOSE:
+!>      Writes data out to NetCDF file. Applying data packing if required.
+!>      Intended to write "chunks" of data out to a file with one "unlimited"
+!>      dimension and takes a single positional argument which is the starting
+!>      index along the "unlimited" dimension.
+!
+! CATEGORY:
+!
+! LANGUAGE:
+!       Fortran-2003
+!
+! CALLING SEQUENCE:
+!       status = Write_Var(ncid, varid, values, start)
+!
+! ARGUMENTS:
+!>@ARG{ncid, in, INTEGER} NetCDF file id
+!>@ARG{varid, in, INTEGER} NetCDF variable id
+!>@ARG{values, in, } data to store
+!>@ARG{start, in, INTEGER\, DIMENSION(:)} index along final dimensions to start write
+!
+! RESULT:
+!>@RES{status, INTEGER} NetCDF error status
+!
+! CALLS:
+!       Get_Var_Ranges
+!       Get_VarInfo
+!       Quantize
+!       Pack_Data
+!       nf90_inquire_variable
+!       nf90_put_var
+!
+! SIDE EFFECTS:
+!>@SIDE Calls NetCDF library to output data
+!
+! RESTRICTIONS:
+!       Size of values must not exceed size of NetCDF variable
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 26/09/2008
+!                     IAES, University of Edinburgh
+!       09/03/2011:   Moved to GbcsNetCDF module and added called to Is_Packed
+!                     and Pack_Data functions.
+!       26/10/2018:   Add inplace quantization (requires Fortran-2003)
+!F-
+!------------------------------------------------------------------------------
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var1F
+!
+! PURPOSE:
+!       Write a 1d array of Single precision REALs to NetCDF variable
+  FUNCTION Write_Var1F(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    REAL(KIND=GbcsReal), DIMENSION(:),     INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var1F'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    TYPE(VarInfo)         :: inf
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+    REAL, ALLOCATABLE, DIMENSION(:) :: buffer
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+    inf = Get_VarInfo(ncid, varid)
+
+    IF (inf%Is_Packed .OR. inf%Use_lsd) THEN
+      buffer = values
+      IF (inf%Use_lsd)   CALL Quantize(buffer, inf%precision)
+      IF (inf%Is_Packed) CALL Pack_Data(buffer, inf)
+      status = nf90_put_var(ncid, varid, buffer, nc_start(1:ndims), nc_count(1:ndims))
+    ELSE
+      status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+    END IF
+
+  END FUNCTION Write_Var1F
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var1I
+!
+! PURPOSE:
+!       Write a 1d array of INTEGERs to NetCDF variable
+  FUNCTION Write_Var1I(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var1I'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+
+    status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+
+  END FUNCTION Write_Var1I
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var2D
+!
+! PURPOSE:
+!       Write a 2d array of Double precision REALs to NetCDF variable
+  FUNCTION Write_Var2D(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    REAL(KIND=GbcsDble), DIMENSION(:,:),   INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var2D'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    TYPE(VarInfo)         :: inf
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+    REAL(KIND=GbcsDble), ALLOCATABLE, DIMENSION(:,:) :: buffer
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+    inf = Get_VarInfo(ncid, varid)
+
+    IF (inf%Is_Packed .OR. inf%Use_lsd) THEN
+      buffer = values
+      IF (inf%Use_lsd)   CALL Quantize(buffer, inf%precision)
+      IF (inf%Is_Packed) CALL Pack_Data(buffer, inf)
+      status = nf90_put_var(ncid, varid, buffer, nc_start(1:ndims), nc_count(1:ndims))
+    ELSE
+      status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+    END IF
+
+  END FUNCTION Write_Var2D
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var2F
+!
+! PURPOSE:
+!       Write a 2d array of Single precision REALs to NetCDF variable
+  FUNCTION Write_Var2F(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    REAL(KIND=GbcsReal), DIMENSION(:,:),   INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var2F'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    TYPE(VarInfo)         :: inf
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+    REAL, ALLOCATABLE, DIMENSION(:,:) :: buffer
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+    inf = Get_VarInfo(ncid, varid)
+
+    IF (inf%Is_Packed .OR. inf%Use_lsd) THEN
+      buffer = values
+      IF (inf%Use_lsd)   CALL Quantize(buffer, inf%precision)
+      IF (inf%Is_Packed) CALL Pack_Data(buffer, inf)
+      status = nf90_put_var(ncid, varid, buffer, nc_start(1:ndims), nc_count(1:ndims))
+    ELSE
+      status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+    END IF
+
+  END FUNCTION Write_Var2F
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var2I
+!
+! PURPOSE:
+!       Write a 2d array of INTEGERs to NetCDF variable
+  FUNCTION Write_Var2I(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    INTEGER,             DIMENSION(:,:),   INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var2I'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+
+    status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+
+  END FUNCTION Write_Var2I
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var2S
+!
+! PURPOSE:
+!       Write a 2d array of 2-byte INTEGERs to NetCDF variable
+  FUNCTION Write_Var2S(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    INTEGER(KIND=GbcsInt2), DIMENSION(:,:),INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var2S'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+
+    status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+
+  END FUNCTION Write_Var2S
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Write_Var2B
+!
+! PURPOSE:
+!       Write a 2d array of 1-byte INTEGERs to NetCDF variable
+  FUNCTION Write_Var2B(ncid, varid, values, start ) RESULT(status)
+    IMPLICIT NONE
+
+    ! ---------
+    ! Arguments
+    ! ---------
+    INTEGER,                               INTENT(IN) :: ncid
+    INTEGER,                               INTENT(IN) :: varid
+    INTEGER(KIND=GbcsInt1), DIMENSION(:,:),INTENT(IN) :: values
+    INTEGER,             DIMENSION(:),     INTENT(IN) :: start
+
+    ! ---------
+    ! Function result
+    ! ---------
+    INTEGER               :: status
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    CHARACTER( * ),        PARAMETER :: ROUTINE_NAME = 'Write_Var2B'
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER, DIMENSION(max_nc_dims) :: nc_start, nc_count, nc_map
+    INTEGER               :: ndims
+
+
+    status = nf90_inquire_variable(ncid, varid, ndims=ndims)
+    IF (status /= nf90_noerr) RETURN
+
+    CALL Get_Var_Ranges(start, SHAPE(values), ndims, nc_start, nc_count, nc_map)
+
+    status = nf90_put_var(ncid, varid, values, nc_start(1:ndims), nc_count(1:ndims))
+
+  END FUNCTION Write_Var2B
+
+
+!------------------------------------------------------------------------------
+!F+
+! NAME:
+!       Quantize
+!
+! PURPOSE:
+!>      Round a REAL number to the nearest power of two which provides the
+!>      specified precision.
+!
+! CATEGORY:
+!       NetCDF
+!
+! LANGUAGE:
+!       Fortran-95
+!
+! CALLING SEQUENCE:
+!       CALL Quantize(value, precision)
+!
+! ARGUMENTS:
+!>@ARG{value, inout, REAL} Number to quantize
+!>@ARG{precision, in, REAL} Desired precision (e.g. 0.1)
+!
+! CALLS:
+!       None
+!
+! SIDE EFFECTS:
+!       None
+!
+! RESTRICTIONS:
+!       None
+!
+! PROCEDURE:
+!
+! CREATION HISTORY:
+!       19/12/2017  OE  Creation
+!F-
+!------------------------------------------------------------------------------
+  PURE SUBROUTINE Quantize_Scalar(value, precision)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL, INTENT(INOUT) :: value
+    REAL, INTENT(IN)    :: precision
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    REAL, PARAMETER :: ilog2 = -1.0 / LOG(2.0)
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    REAL :: scale
+
+    scale = 2.0 ** CEILING(ilog2 * LOG(precision))
+
+    IF (1/scale > SPACING(value)) THEN
+      value = ANINT(value*scale)/scale
+    END IF
+
+  END SUBROUTINE Quantize_Scalar
+
+  PURE SUBROUTINE Quantize_1F(array, precision)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL, DIMENSION(:), INTENT(INOUT) :: array
+    REAL,               INTENT(IN)    :: precision
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    REAL, PARAMETER :: ilog2 = -1.0 / LOG(2.0)
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    REAL :: scale
+    INTEGER :: i
+
+    scale = 2.0 ** CEILING(ilog2 * LOG(precision))
+
+    DO i=1, SIZE(array)
+      IF (1/scale > SPACING(array(i))) THEN
+        array(i) = ANINT(array(i)*scale)/scale
+      END IF
+    END DO
+
+  END SUBROUTINE Quantize_1F
+
+  PURE SUBROUTINE Quantize_2F(array, precision)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL, DIMENSION(:,:), INTENT(INOUT) :: array
+    REAL,                 INTENT(IN)    :: precision
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    REAL, PARAMETER :: ilog2 = -1.0 / LOG(2.0)
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    REAL :: scale
+    INTEGER :: i, j
+
+    scale = 2.0 ** CEILING(ilog2 * LOG(precision))
+
+    DO j=1, SIZE(array,2)
+      DO i=1, SIZE(array,1)
+        IF (1/scale > SPACING(array(i,j))) THEN
+          array(i,j) = ANINT(array(i,j)*scale)/scale
+        END IF
+      END DO
+    END DO
+
+  END SUBROUTINE Quantize_2F
+
+  PURE SUBROUTINE Quantize_2D(array, precision)
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    REAL(KIND=GbcsDble), DIMENSION(:,:), INTENT(INOUT) :: array
+    REAL,                                INTENT(IN)    :: precision
+
+    ! ----------------
+    ! Local parameters
+    ! ----------------
+    REAL(KIND=GbcsDble), PARAMETER :: ilog2 = -1.0 / LOG(2.0)
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    REAL(KIND=GbcsDble) :: scale
+    INTEGER :: i, j
+
+    scale = 2.0 ** CEILING(ilog2 * LOG(precision))
+
+    DO j=1, SIZE(array,2)
+      DO i=1, SIZE(array,1)
+        IF (1/scale > SPACING(array(i,j))) THEN
+          array(i,j) = ANINT(array(i,j)*scale)/scale
+        END IF
+      END DO
+    END DO
+
+  END SUBROUTINE Quantize_2D
+
+END MODULE GbcsNetCDF

--- a/GbcsPath.f90
+++ b/GbcsPath.f90
@@ -33,10 +33,8 @@
 !       Written by:   Owen Embury 11/10/2011
 !                     IAES, University of Edinburgh
 !
-!
-!    Copyright 2008 Chris Merchant, Chris Old, and Owen Embury
-!    The Institute of Atmospheric and Environmental Science
-!    The University of Edinburgh, UK
+!    Copyright 2021 Owen Embury, and Claire Bulgin
+!    Department of Meteorology, University of Reading, UK
 !
 !    This file is part of the GBCS software package.
 !
@@ -53,7 +51,6 @@
 !    You should have received a copy of the GNU General Public License
 !    along with the GBCS software package.
 !    If not, see <http://www.gnu.org/licenses/>.
-!
 !M-
 !------------------------------------------------------------------------------
 MODULE GbcsPath

--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,18 @@ else
 endif
 
 
-all: Preprocess_SLSTR s3regrid
+all: s3testpp s3regrid
 
 clean:
-	$(RM) Preprocess_SLSTR s3regrid
+	$(RM) s3testpp s3regrid
 	$(RM) *.o *.mod
 
-Preprocess_SLSTR: Preprocess_SLSTR.o SLSTR_Preprocessor.o GbcsPath.o
+s3testpp: s3testpp.o SLSTR_Preprocessor.o GbcsPath.o
 s3regrid: s3regrid.o GbcsKinds.o GbcsNetCDF.o GbcsPath.o SLSTR_Preprocessor.o
 
 # Dependencies
 SLSTR_Preprocessor.o: SLSTR_Preprocessor.f90 GbcsPath.o
-Preprocess_SLSTR.o: Preprocess_SLSTR.f90 SLSTR_Preprocessor.o GbcsPath.o
+s3testpp.o: s3testpp.f90 SLSTR_Preprocessor.o GbcsPath.o
 GbcsPath.o: GbcsPath.f90
 GbcsKinds.o: GbcsKinds.f90
 GbcsNetCDF.o: GbcsNetCDF.f90

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,35 @@
+# Customise for your system, you will need netcdf libraries installed
+FC = gfortran
+INCLUDES = -I/usr/lib64/gfortran/modules
+LDFLAGS = -L/usr/local/lib
+LDLIBS = -lnetcdff
 
 ifdef DEBUG
-    COMPILE_FLAGS = -g -fbounds-check
+    FC_FLAGS = -Og -g -fcheck=all
 else
-    COMPILE_FLAGS = -O3
+    FC_FLAGS = -O2
 endif
 
-# Customise for your system, you will need netcdf libraries installed
-FORTRAN = gfortran
-INCDIRS = -I/usr/local/include
-LIBDIRS = -L/usr/local/lib
 
 all: Preprocess_SLSTR
 
-SLSTR_Preprocessor.o: SLSTR_Preprocessor.f90 GbcsPath.o
-	$(FORTRAN) $(COMPILE_FLAGS) $(INCDIRS) -c -o SLSTR_Preprocessor.o SLSTR_Preprocessor.f90
-
-Preprocess_SLSTR.o: Preprocess_SLSTR.f90 SLSTR_Preprocessor.o GbcsPath.o
-	$(FORTRAN) $(COMPILE_FLAGS) $(INCDIRS) -c -o Preprocess_SLSTR.o Preprocess_SLSTR.f90
-
-GbcsPath.o:GbcsPath.f90
-	$(FORTRAN) $(COMPILE_FLAGS) $(INCDIRS) -c -o GbcsPath.o GbcsPath.f90
-
-Preprocess_SLSTR: SLSTR_Preprocessor.o Preprocess_SLSTR.o GbcsPath.o
-	$(FORTRAN) $(LIBDIRS) $(LDFLAGS) -lnetcdff Preprocess_SLSTR.o SLSTR_Preprocessor.o GbcsPath.o -o Preprocess_SLSTR
-
 clean:
-	rm -f Preprocess_SLSTR
-	rm -f *.o
-	rm -f *.mod
+	$(RM) Preprocess_SLSTR
+	$(RM) *.o *.mod
+
+Preprocess_SLSTR: Preprocess_SLSTR.o SLSTR_Preprocessor.o GbcsPath.o
+
+
+# Dependencies
+SLSTR_Preprocessor.o: SLSTR_Preprocessor.f90 GbcsPath.o
+Preprocess_SLSTR.o: Preprocess_SLSTR.f90 SLSTR_Preprocessor.o GbcsPath.o
+GbcsPath.o: GbcsPath.f90
+
+
+# Default rules
+%.o : %.f90
+	$(FC) $(FC_FLAGS) $(INCLUDES) -c $< -o $@
+
+# Always link using Fortran
+LINK.o = $(FC) $(FC_FLAGS) $(LDFLAGS)
+# Alternatively we could use explicit: $(FC) $(LDFLAGS) $^ $(LDLIBS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -11,19 +11,22 @@ else
 endif
 
 
-all: Preprocess_SLSTR
+all: Preprocess_SLSTR s3regrid
 
 clean:
-	$(RM) Preprocess_SLSTR
+	$(RM) Preprocess_SLSTR s3regrid
 	$(RM) *.o *.mod
 
 Preprocess_SLSTR: Preprocess_SLSTR.o SLSTR_Preprocessor.o GbcsPath.o
-
+s3regrid: s3regrid.o GbcsKinds.o GbcsNetCDF.o GbcsPath.o SLSTR_Preprocessor.o
 
 # Dependencies
 SLSTR_Preprocessor.o: SLSTR_Preprocessor.f90 GbcsPath.o
 Preprocess_SLSTR.o: Preprocess_SLSTR.f90 SLSTR_Preprocessor.o GbcsPath.o
 GbcsPath.o: GbcsPath.f90
+GbcsKinds.o: GbcsKinds.f90
+GbcsNetCDF.o: GbcsNetCDF.f90
+s3regrid.o: s3regrid.f90 GbcsKinds.o GbcsNetCDF.o GbcsPath.o SLSTR_Preprocessor.o
 
 
 # Default rules

--- a/Preprocess_SLSTR.f90
+++ b/Preprocess_SLSTR.f90
@@ -34,9 +34,8 @@
 !     Written by:  Niall McCarroll 12/01/21
 !                University of Reading
 !
-!  Copyright 2020 Chris Merchant, Owen Embury, and Claire Bulgin
-!  The Institute of Atmospheric and Environmental Science
-!  The University of Edinburgh, UK
+!  Copyright 2021 Owen Embury, and Claire Bulgin
+!  Department of Meteorology, University of Reading, UK
 !
 !  This file is part of the GBCS software package.
 !

--- a/README.md
+++ b/README.md
@@ -1,28 +1,171 @@
-# slstr-preprocessor
+# SLSTR Preprocessor
 
-Fortran library code and test driver program for aggregating visual channels in SLSTR scenes to the IR grid
+Software for aggregating the SLSTR 500 m Vis/NIR channels (S1-6) onto
+the 1 km IR grid ("i-stripe" as used for S7-9). Two programs are
+included at present:
+* `s3testpp` - test program allowing control over aggregation settings
+* `s3regrid` - program to produce minimal volume "SLSTR-Lite" files
 
-* The preprocessor works by first computing a neighbourhood of visual pixels in a scene that are closest to each IR pixel
-  
-  * Neighbourhoods are defined using the K nearest neighbours that lie within a maximum radius
-  * Cartesian distances are used, based on along-track and across-track offsets of each pixel
-  * Cosmetically filled pixels are ignored to avoid making a double contribution to the output
-  * Choose from using the a-stripe or (where available) the b-stripe or a combination of a-stripe and b-stripe
+
+## Introduction
+
+The Sea and Land Surface Temperature Radiometer (SLSTR) instruments are
+dual-view scanning radiometers with Vis/NIR reflectance channels at 500 m
+and thermal infrared at 1 km resolution. These are measured on a conical
+scan before being remapped to a regular image grid aligned with the
+satellite track. It is commonly assumed that the 500 m Vis/NIR channels
+can be matched to the IR channels with a simple 2x2 averaging. However,
+this results in misalignments between the two due to the previous mapping
+from measurement to image grid. For details see:
+[Bulgin et al. 2023](https://dx.doi.org/10.1016/j.rse.2023.113531)
+
+The preprocessor can be used to correctly aggregate channels S1-6 to the
+locations of channels S7-9 using nearest-neighbour algorithm. This works
+as follows:
+
+* First we compute a neighbourhood of Vis/NIR pixels that are closest to
+  each target IR pixel
+  * Neighbourhoods are defined using the K nearest neighbours that lie
+    within a maximum radius
+  * Cartesian distances are used, based on along-track and across-track
+    offsets of each pixel
+  * Cosmetically filled Vis/NIR pixels are ignored to avoid making a
+    double contribution to the output
+  * Orphan pixels are used in the neighbourhood
+  * Choose from using the a-stripe or (where available) the b-stripe or
+    a combination of a-stripe and b-stripe
     
-* For each visual band, IR compatible rasters are then computed from all pixels which are not missing or cosmetically filled within
-  the neighbourhood of each IR pixel, using the specified aggregation function(s).
+* For each reflectance band, IR compatible rasters are then computed from all
+  valid Vis/NIR pixels within the neighbourhood of each IR pixel, using the
+  specified aggregation function(s).
 
-  * If no suitable pixels appear in the neighbourhood, a missing value is used
-  * MEAN, MAX, SD (population standard deviation) and MAX-MIN aggregations are supported and other ones can easily be added
+  * A missing value is set if there are no suitable pixels in the neighbourhood
+  * MEAN, MAX, SD (population standard deviation) and MAX-MIN aggregations
+    are supported and other ones can easily be added
     
-* For comparison purposes, a `simple` mode is provided which ignores the along and across track distances and aggregates the visible
-  band value for an IR pixel at indexes (x,y) by agggregating the 4 visible pixels at indexes (2x,2y),(2x+1,2y),(2x,2y+1),(2x+1,2y+1)
+* For comparison purposes, a `simple` mode is provided which ignores the
+  along and across track distances and aggregates the visible band value
+  for an IR pixel at indexes (x,y) by agggregating the 4 visible pixels at
+  indexes (2x,2y),(2x+1,2y),(2x,2y+1),(2x+1,2y+1)
   
-This software processes L1 scenes from the Sentinel 3A/3B SLSTR satellites as described here:
 
-https://sentinel.esa.int/documents/247904/1872792/Sentinel-3-SLSTR-Product-Data-Format-Specification-Level-1
+**Note** - the product specification for Sentinel 3A/3B SLSTR data is available
+from: https://sentinel.esa.int/documents/247904/1872792/Sentinel-3-SLSTR-Product-Data-Format-Specification-Level-1
 
-## Fortran module and test program
+
+
+## Installation
+
+1. Download the source code or clone the repo.
+2. Update compiler settings in [Makefile](Makefile). The default configuration
+   is for gfortra. Make sure you specify the correct location for your local installation of [netcdf-fortran](https://github.com/Unidata/netcdf-fortran)
+3. Build with:
+```bash
+make clean
+make
+```
+
+
+## s3regrid
+
+The `s3regrid` program can be used to create "SLSTR-lite" files where the 500 m
+Vis/NIR "a-stripe" and "b-stripe" data are replaced with regridded 1 km as
+"i-stripe" data. This program was originally developed for the [ESA CCI SST project](https://climate.esa.int/en/projects/sea-surface-temperature/).
+
+A Python wrapper is supplied to unzip the input full-size SLSTR L1b, call the
+Fortran exectuable, and create a zip of the output SLSTR-lite. In order to
+minimise the size of the output files the wrapper will also:
+* Remove all "a", "b", "c", and "f" -stripe files with one exception:
+  * `S?_quality_a?.nc` files are retained as these contain the Vis/NIR
+    calibration data.
+* Remove the following files:
+  * `met_tx.nc` - We assume user will be using ERA-5 fields available on CEDA
+  * i-stripe F2 data - as f-stripe F1 data was already removed above
+* Delete all variables from files: `cartesian_in.nc` and `cartesian_io.nc`
+  * The empty files are retained as some readers parse the global metadata
+    contained in these.
+* Remove elevation and orphan pixel information from `geodetic_in.nc` and
+  `geodetic_io.nc`
+
+
+### Usage
+`s3regrid.py [-h] [--cut-dirs CUT_DIRS] [--prefix PREFIX] file [file ...]`
+
+Positional arguments:
+* `file` : Input SLSTR L1b zip file(s)
+
+Options:
+ * `-h`, `--help` : show this help message and exit
+ * `--cut-dirs CUT_DIRS` : Cut this number of directory components
+ * `--prefix PREFIX` : Output directory prefix (defult current directory)
+
+### Example
+
+`s3regrid.py /neodc/sentinel3a/data/SLSTR/L1_RBT/2020/01/01/S3A_*.zip --cut-dirs=5`
+
+Will process all files located in the 1st Jan 2020 directory from the CEDA
+archive and save regridded output files into the local directory 2020/01/01
+(as we are cutting the first 5 path components: neodc...L1_RBT)
+
+
+## s3testpp
+
+To run the test program, supply the input folder containing an SLSTR scene
+and specify the output folder into which the output files S*_radiance_in.nc
+and S*radiance_io.nc are written.
+
+* first, unzip the scene if zipped.  In the example below, the file is unzipped into the folder containing the `s3testpp` executable.
+
+```
+unzip S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.zip
+```
+
+* run with neighbourhood calculation, output files to /tmp:
+
+```
+./s3testpp S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp
+```
+
+* run without neighbourhood calculation (old behaviour):
+
+```
+./s3testpp S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
+         --simple
+```
+
+* run with neighbourhood calculation and print basic neighbourhood statistics:
+
+```
+./s3testpp S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
+         --stats
+```
+
+* run with neighbourhood calculation, using K=6 and setting the maximum distance
+  of a neighbour to 4000m:
+
+```
+./s3testpp S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
+          --effective_k 6 --max_distance 4000
+```
+
+### Output files and variables
+
+For each visible channel C (1-6), a pair of output files are generated with the data regridded on the IR nadir and oblique angle grids, for example for channel 1 these are named:
+
+* `S1_radiance_in.nc` - for nadir view
+* `S1_radiance_io.nc` - for oblique view
+
+Inside each file, with the default configuration, variables will be created for each aggregation function supported.
+
+For example, in `S1_radiance_in.nc` the following variables will be created:
+
+* `S1_radiance_max` - value is the maximum pixel value within the neighbourhood
+* `S1_radiance_mean` - value is the mean pixel value within the neighbourhood
+* `S1_radiance_min_max_diff` - value is the difference between the max and min values within the neighbourhood
+* `S1_radiance_sd` - value is the population standard deviation of values in the neighbourhood
+
+
+## Using the preprocessor in your own code
 
 A [fortran integration module](SLSTR_Preprocessor.f90) should be linked with a client program to integrate this functionality.
 
@@ -97,73 +240,4 @@ The most commonly used parameter sets the maximum limit on the number of neighbo
 INTEGER, PARAMETER :: MAX_K_NEAREST_NEIGHBOURS = 10
 ```
 
-## Building the code and test program
-
-A [standalone test program Preprocess_SLSTR](Preprocess_SLSTR.f90) which can be linked with this module is also provided.
-
-To build the test program clone this repo, cd into its root directory and then run:
-
-```
-make clean
-make
-```
-
-This should build an executable `Preprocess_SLSTR` in the current folder.  The Makefile expects:
-
-* gfortran to be installed
-* netcdf fortran libraries (libnetcdff) installed to `/usr/local/lib` (libraries) and `/usr/local/include` (headers)
-
-## Running the module via the test program Preprocess_SLSTR
-
-To run the test program, supply the input folder containing an SLSTR scene 
-and specify the output folder into which the output files S*_radiance_in.nc and S*radiance_io.nc are written.
-
-* first, unzip the scene if zipped.  In the example below, the file is unzipped into the folder containing the Preprocess_SLSTR executable.
-
-```
-unzip S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.zip
-```
-
-* run with neighbourhood calculation, output files to /tmp:
-
-```
-./Preprocess_SLSTR S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp
-```
-
-* run without neighbourhood calculation (old behaviour):
-
-```
-./Preprocess_SLSTR S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
-         --simple
-```
-
-* run with neighbourhood calculation and print basic neighbourhood statistics:
-
-```
-./Preprocess_SLSTR S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
-         --stats
-```
-
-* run with neighbourhood calculation, using K=6 and setting the maximum distance of a neighbour to 4000m:
-
-```
-./Preprocess_SLSTR S3A_SL_1_RBT____20200101T235811_20200102T000111_20200103T033745_0179_053_187_3420_LN2_O_NT_003.SEN3 /tmp 
-          --effective_k 6 --max_distance 4000
-```
-
-## Output files and variables
-
-For each visible channel C (1-6), a pair of output files are generated with the data regridded on the IR nadir and oblique angle grids, for example for channel 1 these are named:
-
-* `S1_radiance_in.nc` - for nadir view
-* `S1_radiance_io.nc` - for oblique view
-
-Inside each file, with the default configuration, variables will be created for each aggregation function supported.
-
-For example, in `S1_radiance_in.nc` the following variables will be created:
-
-* `S1_radiance_max` - value is the maximum pixel value within the neighbourhood
-* `S1_radiance_mean` - value is the mean pixel value within the neighbourhood
-* `S1_radiance_min_max_diff` - value is the difference between the max and min values within the neighbourhood
-* `S1_radiance_sd` - value is the population standard deviation of values in the neighbourhood
 

--- a/SLSTR_Preprocessor.f90
+++ b/SLSTR_Preprocessor.f90
@@ -53,9 +53,8 @@
 !     Written by:  Niall McCarroll 12/01/21
 !                University of Reading
 !
-!  Copyright 2020 Chris Merchant, Owen Embury, and Claire Bulgin
-!  The Institute of Atmospheric and Environmental Science
-!  The University of Edinburgh, UK
+!  Copyright 2021 Owen Embury, and Claire Bulgin
+!  Department of Meteorology, University of Reading, UK
 !
 !  This file is part of the GBCS software package.
 !

--- a/SLSTR_Preprocessor.f90
+++ b/SLSTR_Preprocessor.f90
@@ -1612,7 +1612,6 @@ CONTAINS
     TYPE(ORPHAN_LOCATIONS) :: orphan_cartesian
     INTEGER, ALLOCATABLE, DIMENSION(:,:) :: iflags
     REAL, ALLOCATABLE, DIMENSION(:,:) :: s8_bt
-    INTEGER :: ix, iy
 
 
     IF (stripe == 'a') THEN

--- a/s3regrid.f90
+++ b/s3regrid.f90
@@ -1,0 +1,132 @@
+!------------------------------------------------------------------------------
+!P+
+! NAME:
+!       s3regrid
+!
+! PURPOSE:
+!>      Process a SLSTR SAFE directory and regrid the Vis/NIR channels (S1-6)
+!>      onto the i-grid
+!
+! CATEGORY:
+!       SLSTR pre-processing
+!
+! LANGUAGE:
+!       Fortran-2003
+!
+! MODULES:
+!       SLSTR_Preprocessor
+!
+! NOTES:
+!
+! CREATION HISTORY:
+!       Written by:   Owen Embury 12/11/2021
+!                     University of Reading
+!
+!    Copyright 2021 Owen Embury, and Claire Bulgin
+!    Department of Meteorology, University of Reading, UK
+!
+!    This file is part of the GBCS software package.
+!
+!    The GBCS software package is free software: you can redistribute it
+!    and/or modify it under the terms of the GNU General Public License
+!    as published by the Free Software Foundation, either version 3 of
+!    the License, or (at your option) any later version.
+!
+!    The GBCS software package is distributed in the hope that it will be
+!    useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+!    of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!    GNU General Public License for more details.
+!
+!    You should have received a copy of the GNU General Public License
+!    along with the GBCS software package.
+!    If not, see <http://www.gnu.org/licenses/>.
+!P-
+!------------------------------------------------------------------------------
+PROGRAM s3regrid
+  ! ------------
+  ! Modules used
+  ! ------------
+  IMPLICIT NONE
+
+  ! ---------
+  ! Variables
+  ! ---------
+  CHARACTER(len=256) :: s3path
+
+  CALL GET_COMMAND_ARGUMENT(1, s3path)
+
+  CALL process_view(s3path, 'n', 5)
+  CALL process_view(s3path, 'o', 5)
+
+CONTAINS
+  SUBROUTINE process_view(path, view, nnear)
+    USE netcdf
+    USE GbcsKinds
+    USE GbcsNetCDF
+    USE GbcsPath
+    USE SLSTR_Preprocessor
+    IMPLICIT NONE
+    ! ---------
+    ! Arguments
+    ! ---------
+    CHARACTER(LEN=*), INTENT(in) :: path
+    CHARACTER(LEN=1), INTENT(in) :: view
+    INTEGER,          INTENT(in) :: nnear
+
+    ! ---------------
+    ! Local variables
+    ! ---------------
+    INTEGER :: status, ncid, dim1, dim2, varid
+    INTEGER :: iband
+    INTEGER, DIMENSION(2) :: irsize
+    CHARACTER(len=14) :: name
+    CHARACTER(len=64) :: attr_long, attr_name, attr_unit
+    INTEGER(KIND=GbcsInt2) :: fill
+    TYPE(NEIGHBOURHOOD_MAP) :: nnmap
+    REAL :: scale, offset
+    REAL, ALLOCATABLE, DIMENSION(:,:) :: rads
+
+    WRITE(*,*) "Calculating nearest neighbours: ", view
+    CALL compute_scene_neighbourhood(view, path, nnmap, 'a')
+    irsize = SHAPE(nnmap%entries)
+    WRITE(*,*) "Output size: ", irsize
+    ALLOCATE(rads(irsize(1), irsize(2)))
+
+    DO iband = 1,6
+      ! Read attributes from input radiance
+      WRITE(name, '("S", I1, "_radiance_a", A1)') iband, view
+      status = nf90_open(Path_Join(path, name//'.nc'), NF90_NOWRITE, ncid)
+      status = nf90_inq_varid(ncid, name, varid)
+      status = nf90_get_att(ncid, varid, '_FillValue', fill)
+      status = nf90_get_att(ncid, varid, 'add_offset', offset)
+      status = nf90_get_att(ncid, varid, 'scale_factor', scale)
+      status = nf90_get_att(ncid, varid, 'long_name', attr_long)
+      status = nf90_get_att(ncid, varid, 'standard_name', attr_name)
+      status = nf90_get_att(ncid, varid, 'units', attr_unit)
+      status = nf90_close(ncid)
+
+      WRITE(name, '("S", I1, "_radiance_i", A1)') iband, view
+      WRITE(*,*) 'Channel: ', name
+      CALL process_scene_band(view, path, iband, rads, nnmap, nnear, FUNCTION_MEAN)
+      status = nf90_create(Path_Join(path, name//'.nc'), NF90_NETCDF4, ncid)
+      status = nf90_def_dim(ncid, "columns", irsize(1), dim1)
+      status = nf90_def_dim(ncid, "rows", irsize(2), dim2)
+      status = nf90_def_var(ncid, name, nf90_short, [dim1, dim2], varid, &
+                            chunksizes=irsize, deflate_level=2, shuffle=.True.)
+      status = nf90_put_att(ncid, varid, '_FillValue', fill)
+      status = nf90_put_att(ncid, varid, 'add_offset', offset)
+      status = nf90_put_att(ncid, varid, 'scale_factor', scale)
+      status = nf90_put_att(ncid, varid, 'valid_min', -3000_GbcsInt2)
+      status = nf90_put_att(ncid, varid, 'valid_max', 32767_GbcsInt2)
+      status = nf90_put_att(ncid, varid, 'long_name', attr_long)
+      status = nf90_put_att(ncid, varid, 'standard_name', attr_name)
+      status = nf90_put_att(ncid, varid, 'units', attr_unit)
+      status = nf90_enddef(ncid)
+
+      status = Write_Var(ncid, varid, rads, [1, 1])
+      status = nf90_close(ncid)
+    END DO
+
+  END SUBROUTINE process_view
+
+END PROGRAM s3regrid

--- a/s3regrid.py
+++ b/s3regrid.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python
+"""
+Script to regrid SLSTR Vis/NIR channels to the 1 km IR "i stripe"
+Also removes fire channels and met_tx data to reduce file size.
+
+Usage:
+    s3regrid.py [-h] [--cut-dirs CUT_DIRS] [--prefix PREFIX] file [file ...]
+
+Arguments:
+  file                 Input SLSTR zip file(s)
+
+Optional arguments:
+  -h, --help           show this help message and exit
+  --cut-dirs CUT_DIRS  Cut this number of directory components
+  --prefix PREFIX      Output directory prefix (defult current directory)
+
+Example:
+
+  s3regrid.py /neodc/sentinel3a/data/SLSTR/L1_RBT/2020/01/01/S3A_*.zip --cut-dirs=5
+
+  Will save output files into the local directory 2020/01/01 as it is
+  removing the first 5 path components: neodc...L1_RBT
+
+
+"""
+
+import argparse
+import atexit
+import os
+from pathlib import Path
+import signal
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+import netCDF4
+
+_workdir = tempfile.mkdtemp()   # Working directory for temporary files
+
+
+@atexit.register
+def _final_cleanup():
+    """
+    atexit cleanup code to ensure we delete our tempdir
+    """
+    if _workdir:
+        shutil.rmtree(_workdir)
+
+
+def _catch_signals():
+    """
+    Set the standard signal handlers so we will always call the atexit code and
+    perform appropriate cleanup of the runtime environment.
+    """
+    def _sigtermhandler(signum, frame):
+        sys.exit("Caught signal: {0:d}".format(signum))
+
+    for sig in ['SIGINT', 'SIGTERM', 'SIGUSR1', 'SIGUSR2', 'SIGXCPU']:
+        try:
+            signal.signal(getattr(signal, sig), _sigtermhandler)
+        except AttributeError:
+            pass
+
+
+_catch_signals()
+
+
+def findexec(name):
+    """
+    Look for the s3regrid executable. Default location is same as
+    this script. Otherwise search the PATH environment variable
+    """
+    # exec = os.path.join(os.path.dirname(sys.path[0]), 'bin', name)
+    exec = os.path.join(sys.path[0], name)
+    if os.path.isfile(exec):
+        return exec
+    for path in os.environ['PATH'].split(os.pathsep):
+        exec = os.path.join(path, name)
+        if os.path.isfile(exec):
+            return exec
+    return name
+
+
+def replacenc(filename, vars=None):
+    """
+    Replace the specified netCDF file with a copy which only contains the
+    listed variables
+    """
+    src = netCDF4.Dataset(filename)
+    dst = netCDF4.Dataset(filename+'_copy', 'w')
+    dst.setncatts(src.__dict__)
+    for dim in src.dimensions:
+        if src.dimensions[dim].isunlimited():
+            dst.createDimension(dim, None)
+        else:
+            dst.createDimension(dim, len(src.dimensions[dim]))
+    if vars is None:
+        vars = list(src.variables)
+    for v in vars:
+        var = src.variables[v]
+        opts = var.filters() or {}
+        if var.chunking() and var.chunking() != 'contiguous':
+            opts['chunksizes'] = var.chunking()
+        if hasattr(var, '_FillValue'):
+            opts['fill_value'] = var._FillValue
+        out = dst.createVariable(v, var.dtype, var.dimensions, **opts)
+        out.setncatts(var.__dict__)
+        out[:] = var[:]
+    src.close()
+    dst.close()
+    os.replace(filename+'_copy', filename)
+
+
+def renamenc(src):
+    """
+    Rename the specified netCDF file from a stripe to i. This should only be
+    used on the quality files as it does not regrid data.
+    """
+    if src.name.endswith('_an.nc'):
+        subs = '_an', '_in'
+    elif src.name.endswith('_ao.nc'):
+        subs = '_ao', '_io'
+    else:
+        raise Exception(f'Unrecognised file {src}')
+    with netCDF4.Dataset(src.path, 'a') as nc:
+        for v in list(nc.variables):
+            nc.renameVariable(v, v.replace(*subs))
+    os.rename(src, src.path[:-6] + subs[1] + '.nc')
+
+
+def processzip(filename):
+    zipname = os.path.basename(filename)
+    safename = zipname.replace('.zip', '.SEN3')
+    with zipfile.ZipFile(filename) as zip:
+        # All members should be inside the safedir. If there are any
+        # other files in the zip archive then abort.
+        if [f for f in zip.namelist() if not f.startswith(safename)]:
+            raise Exception('[slstr] Invalid SAFE - files outside safe dir')
+        zip.extractall(_workdir)
+
+    safedir = os.path.join(_workdir, safename)
+    subprocess.run([findexec('s3regrid'), safedir])
+
+    # Copy global attributes including resolution from S9_BT
+    for v in 'no':
+        with netCDF4.Dataset(os.path.join(safedir, f'S9_BT_i{v}.nc')) as nc:
+            attrs = nc.__dict__
+        for c in '123456':
+            with netCDF4.Dataset(os.path.join(safedir, f'S{c}_radiance_i{v}.nc'), 'a') as nc:
+                nc.setncatts(attrs)
+
+    # Remove any files not used for SST-CCI processing
+    for f in os.scandir(safedir):
+        # Need to keep the Vis/NIR quality files
+        if 'quality_a' in f.name:
+            # If needed we can rename the quality file/variables to match the
+            # "i" grid used for data
+            # renamenc(f)
+            pass
+        # All other a/b stripe files can be removed
+        elif f.name[-5:] in ['an.nc', 'ao.nc', 'bn.nc', 'bo.nc', 'cn.nc', 'co.nc', 'fn.nc', 'fo.nc']:
+            os.remove(f)
+        # Also remove fire channel and met_tx
+        elif f.name in ['met_tx.nc', 'F2_BT_in.nc', 'F2_BT_io.nc',
+                        'F2_quality_in.nc', 'F2_quality_io.nc']:
+            os.remove(f)
+
+    # Cartesian and geodetic are the largest remaining files so remove any
+    # variables that are unsed by gbcs
+    replacenc(os.path.join(safedir, 'cartesian_in.nc'), [])
+    replacenc(os.path.join(safedir, 'cartesian_io.nc'), [])
+    replacenc(os.path.join(safedir, 'geodetic_in.nc'), ['latitude_in', 'longitude_in'])
+    replacenc(os.path.join(safedir, 'geodetic_io.nc'), ['latitude_io', 'longitude_io'])
+
+    subprocess.run(['zip', '-r', zipname, safename], cwd=_workdir)
+    shutil.rmtree(safedir)
+    return os.path.join(_workdir, zipname)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('file', nargs='+', help='Input SLSTR zip file(s)')
+    parser.add_argument('--cut-dirs', type=int, default=0, help='Cut this number of directory components')
+    parser.add_argument('--prefix', default='.', help='Output directory prefix')
+    args = parser.parse_args()
+
+
+    for src in args.file:
+        print(f'Processing {src}')
+        spath = Path(src)
+        n = args.cut_dirs + 1 if spath.is_absolute() else args.cut_dirs
+        dst = Path(args.prefix).joinpath(*spath.parts[n:])
+        f = processzip(src)
+
+        os.makedirs(dst.parent, exist_ok=True)
+        shutil.move(f, dst)

--- a/s3testpp.f90
+++ b/s3testpp.f90
@@ -1,7 +1,7 @@
 !--------------------------------------------------------------------------------------------
-!P+ Preprocess_SLSTR
+!P+ s3testpp
 ! NAME:
-!     Preprocess_SLSTR
+!     s3testpp
 !
 ! PURPOSE:
 !
@@ -471,7 +471,7 @@ SUBROUTINE process_view(view_type, scene_folder, output_folder, simple, stats, e
   END DO
 END SUBROUTINE process_view
 
-PROGRAM Preprocess_SLSTR
+PROGRAM s3testpp
   USE SLSTR_Preprocessor
   IMPLICIT NONE
 
@@ -530,4 +530,4 @@ PROGRAM Preprocess_SLSTR
 
   CALL process_view('n',scene_folder,output_folder,simple,stats,effective_k)
   CALL process_view('o',scene_folder,output_folder,simple,stats,effective_k)
-END PROGRAM Preprocess_SLSTR
+END PROGRAM s3testpp


### PR DESCRIPTION
This PR adds:
* the SST-CCI `s3regrid` program for creating SLSTR-lite files
* renames the old test program to `s3testpp` to avoid the confusion between module and program names
* updates readme
* updates Makefile to use more common variables / rules